### PR TITLE
PR_2 fixes; Error handling etc.

### DIFF
--- a/import/build.gradle
+++ b/import/build.gradle
@@ -79,8 +79,6 @@ dependencies {
     compile "com.google.cloud:google-cloud-storage:1.111.2"
     compile 'com.google.cloud:google-cloud-nio:0.121.2'
 
-    testCompile "org.mockito:mockito-core:3.+"
-
     testCompile "com.google.truth:truth:1.0"
     testCompile "org.mockito:mockito-core:3.+"
     testCompile "junit:junit:4.2"

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/Flags.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/Flags.java
@@ -17,6 +17,9 @@ package com.google.cloud.healthcare.imaging.dicomadapter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Parameters(separators = "= ")
 public class Flags {
 
@@ -165,7 +168,7 @@ public class Flags {
           names = {"--persistent_file_upload_retry_amount"},
           description = "upload retry amount"
   )
-  Integer persistentFileUploadRetryAmount = 1;
+  Integer persistentFileUploadRetryAmount = 0;
 
   @Parameter(
           names = {"--min_upload_delay"},
@@ -178,6 +181,12 @@ public class Flags {
           description = "maximum waiting time between uploads (ms)"
   )
   Integer maxWaitingTimeBetweenUploads = 5000;
+
+  @Parameter(
+      names = {"--http_error_codes_to_retry"},
+      description = "http codes list to retry that less than 500."
+  )
+  List<Integer> httpErrorCodesToRetry = new ArrayList<>();
 
   public Flags() {
   }

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/BackupFlags.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/BackupFlags.java
@@ -1,0 +1,33 @@
+package com.google.cloud.healthcare.imaging.dicomadapter.backupuploader;
+
+import java.util.List;
+
+public class BackupFlags {
+  private int attemptsAmount;
+  private int minUploadDelay;
+  private int maxWaitingTimeBtwUpload;
+  private List<Integer> httpErrorCodesToRetry;
+
+  public BackupFlags(int attemptsAmount, int minUploadDelay, int maxWaitingTimeBtwUpload, List<Integer> httpErrorCodesToRetry) {
+    this.attemptsAmount = attemptsAmount;
+    this.minUploadDelay = minUploadDelay;
+    this.maxWaitingTimeBtwUpload = maxWaitingTimeBtwUpload;
+    this.httpErrorCodesToRetry = httpErrorCodesToRetry;
+  }
+
+  public int getAttemptsAmount() {
+    return attemptsAmount;
+  }
+
+  public int getMinUploadDelay() {
+    return minUploadDelay;
+  }
+
+  public int getMaxWaitingTimeBtwUpload() {
+    return maxWaitingTimeBtwUpload;
+  }
+
+  public List<Integer> getHttpErrorCodesToRetry() {
+    return httpErrorCodesToRetry;
+  }
+}

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/DelayCalculator.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/DelayCalculator.java
@@ -5,40 +5,20 @@ public class DelayCalculator {
   private static final double DELAY_CALCULATION_BASE = 2D;
   private static final long MILS_MUL = 1000L;
 
-  private int attemptsAmount;
-  private int minUploadDelay;
-  private int maxWaitingTimeBtwUpload;
-
-  /**
-   * Creates instance of DelayCalculator with flags values from application configuration.
-   * @param attemptsAmount amount of attempts.
-   * @param minUploadDelay left border of final delay result.
-   * @param maxWaitingTimeBtwUpload right border of final delay result.
-   */
-  public DelayCalculator(int attemptsAmount, int minUploadDelay, int maxWaitingTimeBtwUpload) {
-    this.attemptsAmount = attemptsAmount;
-    this.minUploadDelay = minUploadDelay;
-    this.maxWaitingTimeBtwUpload = maxWaitingTimeBtwUpload;
-  }
-
   /**
    * Calculates delay in millis. The result depends on attemptsLeft argument in exponential manner.
    * @param attemptsLeft used for calculation ot the pow in the formula.
    * @return delay in millis
    */
-  public long getExponentialDelayMillis(int attemptsLeft) {
-    long delay = 0;
+  public long getExponentialDelayMillis(int attemptsLeft, BackupFlags backupFlags) {
+    int maxWaitingTimeBtwUpload = backupFlags.getMaxWaitingTimeBtwUpload();
     if (attemptsLeft < 1) {
-      return minUploadDelay;
+      return backupFlags.getMinUploadDelay();
     }
-    if (attemptsLeft > attemptsAmount) {
+    if (attemptsLeft > backupFlags.getAttemptsAmount()) {
       return maxWaitingTimeBtwUpload;
     }
-    delay = (long) (minUploadDelay + (Math.round(Math.pow(DELAY_CALCULATION_BASE, attemptsAmount - attemptsLeft + 1)) - DELAY_CALCULATION_BASE) * MILS_MUL);
-    return (delay >= maxWaitingTimeBtwUpload)?maxWaitingTimeBtwUpload : delay;
-  }
-
-  public int getAttemptsAmount() {
-    return attemptsAmount;
+    long delay = (long) (backupFlags.getMinUploadDelay() + (Math.round(Math.pow(DELAY_CALCULATION_BASE, backupFlags.getAttemptsAmount() - attemptsLeft + 1)) - DELAY_CALCULATION_BASE) * MILS_MUL);
+    return (delay >= maxWaitingTimeBtwUpload) ? maxWaitingTimeBtwUpload : delay;
   }
 }

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/GcpBackupUploader.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/GcpBackupUploader.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
 import java.util.Arrays;
-
 import org.apache.commons.lang3.StringUtils;
 
 public class GcpBackupUploader extends AbstractBackupUploader {
@@ -38,8 +37,7 @@ public class GcpBackupUploader extends AbstractBackupUploader {
   }
 
   @Override
-  public void doWriteBackup(InputStream backupData, String uniqueFileName)
-          throws BackupException {
+  public void doWriteBackup(InputStream backupData, String uniqueFileName) throws BackupException {
     try {
       if (backupData == null) {
         throw new BackupException("Backup data is null");
@@ -77,7 +75,7 @@ public class GcpBackupUploader extends AbstractBackupUploader {
 
   private void parseUploadFilePath(String uploadFilePath) throws GcpUriParseException {
     try {
-      if (!uploadFilePath.startsWith(GCP_PATH_PREFIX)){
+      if (!uploadFilePath.startsWith(GCP_PATH_PREFIX)) {
         throw new GcpUriParseException("Not gcs link");
       }
       validatePathParameter(uploadFilePath, "upload file path");

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/IBackupUploadService.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/IBackupUploadService.java
@@ -1,11 +1,6 @@
 package com.google.cloud.healthcare.imaging.dicomadapter.backupuploader;
 
 import com.google.cloud.healthcare.IDicomWebClient;
-import com.google.cloud.healthcare.imaging.dicomadapter.monitoring.Event;
-import com.google.cloud.healthcare.imaging.dicomadapter.monitoring.MonitoringService;
-import org.eclipse.jetty.http.HttpStatus;
-import org.slf4j.Logger;
-
 import java.io.InputStream;
 
 public interface IBackupUploadService {
@@ -17,22 +12,4 @@ public interface IBackupUploadService {
   void startUploading(IDicomWebClient webClient, BackupState backupState) throws IBackupUploader.BackupException;
 
   void removeBackup(String uniqueFileName);
-
-  static boolean filterHttpCode409(int actualHttpStatus, Logger log) {
-    boolean httpStatus409 = actualHttpStatus == HttpStatus.CONFLICT_409;
-    if (httpStatus409) {
-      MonitoringService.addEvent(Event.CSTORE_409_ERROR);
-      log.error("C-STORE request failed. Got http error with 409.");
-    }
-    return httpStatus409;
-  }
-
-  static boolean filterHttpCode500Plus(int actualHttpStatus, Logger log) {
-    boolean httpStatusMoreThan500 = actualHttpStatus >= HttpStatus.INTERNAL_SERVER_ERROR_500;
-    if (httpStatusMoreThan500) {
-      MonitoringService.addEvent(Event.CSTORE_5xx_ERROR);
-      log.error("C-STORE request failed. Got http error with status 5xx.");
-    }
-    return httpStatusMoreThan500;
-  }
 }

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/IBackupUploader.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/IBackupUploader.java
@@ -12,8 +12,16 @@ public interface IBackupUploader {
   void doRemoveBackup(String uniqueFileName) throws BackupException;
 
   class BackupException extends IOException {
+
+    private Integer dicomStatus;
+
     public BackupException(String message, Throwable cause) {
       super(message, cause);
+    }
+
+    public BackupException(int dicomStatus, Throwable cause) {
+      super(cause);
+      this.dicomStatus = dicomStatus;
     }
 
     public BackupException(String message) {
@@ -22,6 +30,15 @@ public interface IBackupUploader {
 
     public BackupException(Throwable cause) {
       super(cause);
+    }
+
+    public BackupException(int dicomStatus, String message) {
+      super(message);
+      this.dicomStatus = dicomStatus;
+    }
+
+    public Integer getDicomStatus() {
+      return dicomStatus;
     }
   }
 }

--- a/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/monitoring/Event.java
+++ b/import/src/main/java/com/google/cloud/healthcare/imaging/dicomadapter/monitoring/Event.java
@@ -21,8 +21,6 @@ public enum Event implements IMonitoringEvent {
   CSTORE_ERROR(Constants.prefix + "cstore_errors"),
   CSTORE_BACKUP_ERROR(Constants.prefix + "cstore_backup_errors"),
   CSTORE_BYTES(Constants.prefix + "cstore_bytes"),
-  CSTORE_409_ERROR(Constants.prefix + "cstore_409_error"),
-  CSTORE_5xx_ERROR(Constants.prefix + "cstore_5xx_error"),
 
   CFIND_REQUEST(Constants.prefix + "cfind_requests"),
   CFIND_ERROR(Constants.prefix + "cfind_errors"),

--- a/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/BackupStateTest.java
+++ b/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/BackupStateTest.java
@@ -1,8 +1,8 @@
 package com.google.cloud.healthcare.imaging.dicomadapter.backupuploader;
 
-import org.junit.Test;
-
 import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
 
 public class BackupStateTest {
 

--- a/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/DelayCalculatorTest.java
+++ b/import/src/test/java/com/google/cloud/healthcare/imaging/dicomadapter/backupuploader/DelayCalculatorTest.java
@@ -6,35 +6,37 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class DelayCalculatorTest {
-  DelayCalculator calc;
+  private BackupFlags backupFlags;
+  private DelayCalculator calc;
 
   @Before
   public void setup() {
-    calc = new DelayCalculator(5, 100, 5000);
+    backupFlags = new BackupFlags(5, 100, 5000);
+    calc = new DelayCalculator();
   }
 
   @Test
   public void delayOnFirstTry() {
-    assertThat(calc.getExponentialDelayMillis(5)).isEqualTo(100L);
+    assertThat(calc.getExponentialDelayMillis(5, backupFlags)).isEqualTo(100L);
   }
 
   @Test
   public void delayOnLastTry() {
-    assertThat(calc.getExponentialDelayMillis(1)).isEqualTo(5000L);
+    assertThat(calc.getExponentialDelayMillis(1, backupFlags)).isEqualTo(5000L);
   }
 
   @Test
   public void delayOnIntermediateTry() {
-    assertThat(calc.getExponentialDelayMillis(4)).isEqualTo(2100L);
+    assertThat(calc.getExponentialDelayMillis(4, backupFlags)).isEqualTo(2100L);
   }
 
   @Test
   public void delayWithNegativeValue() {
-    assertThat(calc.getExponentialDelayMillis(-3)).isEqualTo(100L);
+    assertThat(calc.getExponentialDelayMillis(-3, backupFlags)).isEqualTo(100L);
   }
 
   @Test
   public void delayWithInvavidAttemptValue() {
-    assertThat(calc.getExponentialDelayMillis(20)).isEqualTo(5000L);
+    assertThat(calc.getExponentialDelayMillis(20, backupFlags)).isEqualTo(5000L);
   }
 }


### PR DESCRIPTION
flags for BackupUploaderService moved from DelayCalculator to BackupFlags, new flag added: --http_error_codes_to_retry;

httpCodes error handling updated: direct check 409 removed, filter by codeList from flag added;
Flags.persistentFileUploadRetryAmount default value changed from 1 to 0;
Event CSTORE_409_ERROR CSTORE_5xx_ERROR types removed;
bugs fixed:
dicomCode now transfers in BackupException to DicomServiceException on retyrySend fail;
CStoreService.removeBackup moved from final block;
ignore any Mockito.verify methods after ExpectedException.expect;
timeout removed from tests;